### PR TITLE
Add Wikidata IDs to title and author ref attributes in level1 XML files

### DIFF
--- a/level1/HU00011.xml
+++ b/level1/HU00011.xml
@@ -7,7 +7,7 @@
    <teiHeader>
       <fileDesc>
          <titleStmt>
-            <title>Derű és ború : ELTeC kiadás</title>
+            <title ref="wikidata:Q111172462">Derű és ború : ELTeC kiadás</title>
             <author>Vachott Sándorné (1828-1896)</author>
             <respStmt>
                <resp>ELTeC conversion</resp>

--- a/level1/HU00012.xml
+++ b/level1/HU00012.xml
@@ -7,7 +7,7 @@
    <teiHeader>
       <fileDesc>
          <titleStmt>
-            <title>Irma hagyományai : ELTeC kiadás</title>
+            <title ref="wikidata:Q111172480">Irma hagyományai : ELTeC kiadás</title>
             <author>Vachott Sándorné (1828-1896)</author>
             <respStmt>
                <resp>ELTeC conversion</resp>

--- a/level1/HU00600.xml
+++ b/level1/HU00600.xml
@@ -7,8 +7,8 @@
    <teiHeader>
       <fileDesc>
          <titleStmt>
-            <title>A gólyakalifa : ELTeC edition</title>
-            <author ref="viaf:49221125">Babits Mihály (1883-1941)</author>
+            <title ref="wikidata:Q12351122">A gólyakalifa : ELTeC edition</title>
+            <author ref="viaf:49221125 wikidata:Q332482">Babits Mihály (1883-1941)</author>
             <respStmt>
                <resp>ELTeC conversion</resp>
                <name>Palkó Gábor<ref target="https://viaf.org/viaf/65989506"/>

--- a/level1/HU00628.xml
+++ b/level1/HU00628.xml
@@ -7,8 +7,8 @@
    <teiHeader>
       <fileDesc>
          <titleStmt>
-            <title>Az ezüst kecske : ELTeC edition</title>
-            <author ref="viaf:49267921">Bródy Sándor (1863-1924)</author>
+            <title ref="wikidata:Q111172453">Az ezüst kecske : ELTeC edition</title>
+            <author ref="viaf:49267921 wikidata:Q738786">Bródy Sándor (1863-1924)</author>
             <respStmt>
                <resp>ELTeC conversion</resp>
                <name>Palkó Gábor<ref target="https://viaf.org/viaf/65989506"/>

--- a/level1/HU00642.xml
+++ b/level1/HU00642.xml
@@ -7,8 +7,8 @@
    <teiHeader>
       <fileDesc>
          <titleStmt>
-            <title>A falu jegyzője : ELTeC edition</title>
-            <author ref="viaf:64044769">Eötvös József (1813-1871)</author>
+            <title ref="wikidata:Q465221">A falu jegyzője : ELTeC edition</title>
+            <author ref="viaf:64044769 wikidata:Q469996">Eötvös József (1813-1871)</author>
             <respStmt>
                <resp>ELTeC conversion</resp>
                <name>Palkó Gábor<ref target="https://viaf.org/viaf/65989506"/>

--- a/level1/HU00662.xml
+++ b/level1/HU00662.xml
@@ -7,8 +7,8 @@
    <teiHeader>
       <fileDesc>
          <titleStmt>
-            <title>A láthatatlan ember : Történelmi regény : ELTeC edition</title>
-            <author ref="viaf:24643507">Gárdonyi Géza (1863-1922)</author>
+            <title ref="wikidata:Q468654">A láthatatlan ember : Történelmi regény : ELTeC edition</title>
+            <author ref="viaf:24643507 wikidata:Q221903">Gárdonyi Géza (1863-1922)</author>
             <respStmt>
                <resp>ELTeC conversion</resp>
                <name>Palkó Gábor<ref target="https://viaf.org/viaf/65989506"/>

--- a/level1/HU00666.xml
+++ b/level1/HU00666.xml
@@ -7,8 +7,8 @@
    <teiHeader>
       <fileDesc>
          <titleStmt>
-            <title>Egy régi udvarház utolsó gazdája : Regény : ELTeC edition</title>
-          <author ref="viaf:59092543">Gyulai Pál (1826–1909)</author>
+            <title ref="wikidata:Q988006">Egy régi udvarház utolsó gazdája : Regény : ELTeC edition</title>
+          <author ref="viaf:59092543 wikidata:Q898398">Gyulai Pál (1826–1909)</author>
             <respStmt>
                <resp>ELTeC conversion</resp>
                <name>Palkó Gábor<ref target="https://viaf.org/viaf/65989506"/>

--- a/level1/HU00719.xml
+++ b/level1/HU00719.xml
@@ -7,8 +7,8 @@
    <teiHeader>
       <fileDesc>
          <titleStmt>
-            <title>Tanár úr kérem : ELTeC edition</title>
-            <author ref="viaf:46762994">Karinthy Frigyes (1887-1938)</author>
+            <title ref="wikidata:Q1316638">Tanár úr kérem : ELTeC edition</title>
+            <author ref="viaf:46762994 wikidata:Q366325">Karinthy Frigyes (1887-1938)</author>
             <respStmt>
                <resp>ELTeC conversion</resp>
                <name>Palkó Gábor<ref target="https://viaf.org/viaf/65989506"/>

--- a/level1/HU00726.xml
+++ b/level1/HU00726.xml
@@ -7,8 +7,8 @@
    <teiHeader>
       <fileDesc>
          <titleStmt>
-            <title>Bácsmegyeinek gyötrelmei : ELTeC edition</title>
-            <author ref="viaf:9867747">Kazinczy Ferenc (1759-1831)</author>
+            <title ref="wikidata:Q111172456">Bácsmegyeinek gyötrelmei : ELTeC edition</title>
+            <author ref="viaf:9867747 wikidata:Q381865">Kazinczy Ferenc (1759-1831)</author>
             <respStmt>
                <resp>ELTeC conversion</resp>
                <name>Palkó Gábor<ref target="https://viaf.org/viaf/65989506"/>

--- a/level1/HU00730.xml
+++ b/level1/HU00730.xml
@@ -7,8 +7,8 @@
    <teiHeader>
       <fileDesc>
          <titleStmt>
-            <title>Özvegy és leánya : ELTeC edition</title>
-            <author ref="viaf:54141095">Kemény Zsigmond (1814-1875)</author>
+            <title ref="wikidata:Q30088095">Özvegy és leánya : ELTeC edition</title>
+            <author ref="viaf:54141095 wikidata:Q427079">Kemény Zsigmond (1814-1875)</author>
             <respStmt>
                <resp>ELTeC conversion</resp>
                <name>Palkó Gábor<ref target="https://viaf.org/viaf/65989506"/>

--- a/level1/HU00731.xml
+++ b/level1/HU00731.xml
@@ -7,8 +7,8 @@
    <teiHeader>
       <fileDesc>
          <titleStmt>
-            <title>Szerelem és hiúság : ELTeC edition</title>
-            <author ref="viaf:54141095">Kemény Zsigmond (1814-1875)</author>
+            <title ref="wikidata:Q111172515">Szerelem és hiúság : ELTeC edition</title>
+            <author ref="viaf:54141095 wikidata:Q427079">Kemény Zsigmond (1814-1875)</author>
             <respStmt>
                <resp>ELTeC conversion</resp>
                <name>Palkó Gábor<ref target="https://viaf.org/viaf/65989506"/>

--- a/level1/HU00763.xml
+++ b/level1/HU00763.xml
@@ -7,8 +7,8 @@
    <teiHeader>
       <fileDesc>
          <titleStmt>
-            <title>Az útitárs : ELTeC edition</title>
-            <author ref="viaf:22810">Krúdy Gyula (1878-1933)</author>
+            <title ref="wikidata:Q111172454">Az útitárs : ELTeC edition</title>
+            <author ref="viaf:22810 wikidata:Q527239">Krúdy Gyula (1878-1933)</author>
             <respStmt>
                <resp>ELTeC conversion</resp>
                <name>Palkó Gábor<ref target="https://viaf.org/viaf/65989506"/>

--- a/level1/HU00879.xml
+++ b/level1/HU00879.xml
@@ -7,8 +7,8 @@
    <teiHeader>
       <fileDesc>
          <titleStmt>
-            <title>Törökországi levelek : Válogatás : ELTeC edition</title>
-            <author ref="viaf:7410168 ">Mikes Kelemen (1690-1761)</author>
+            <title ref="wikidata:Q18571897">Törökországi levelek : Válogatás : ELTeC edition</title>
+            <author ref="viaf:7410168  wikidata:Q540184">Mikes Kelemen (1690-1761)</author>
             <respStmt>
                <resp>ELTeC conversion</resp>
                <name>Palkó Gábor<ref target="https://viaf.org/viaf/65989506"/>

--- a/level1/HU00898.xml
+++ b/level1/HU00898.xml
@@ -7,8 +7,8 @@
    <teiHeader>
       <fileDesc>
          <titleStmt>
-            <title>A beszélő köntös : ELTeC edition</title>
-            <author ref="viaf:46774986">Mikszáth Kálmán (1847-1910)</author>
+            <title ref="wikidata:Q111172417">A beszélő köntös : ELTeC edition</title>
+            <author ref="viaf:46774986 wikidata:Q350552">Mikszáth Kálmán (1847-1910)</author>
             <respStmt>
                <resp>ELTeC conversion</resp>
                <name>Palkó Gábor<ref target="https://viaf.org/viaf/65989506"/>

--- a/level1/HU00949.xml
+++ b/level1/HU00949.xml
@@ -7,9 +7,9 @@
    <teiHeader>
       <fileDesc>
          <titleStmt>
-            <title>A Noszty fiú esete Tóth Marival : ELTeC edition
+            <title ref="wikidata:Q42193532">A Noszty fiú esete Tóth Marival : ELTeC edition
             </title>
-            <author ref="viaf:46774986">Mikszáth Kálmán (1847-1910)           
+            <author ref="viaf:46774986 wikidata:Q350552">Mikszáth Kálmán (1847-1910)           
             </author>
             <respStmt>
                <resp>ELTeC conversion</resp>

--- a/level1/HU00954.xml
+++ b/level1/HU00954.xml
@@ -7,8 +7,8 @@
    <teiHeader>
       <fileDesc>
          <titleStmt>
-            <title>Szent Péter esernyője : ELTeC edition</title>
-            <author ref="viaf:46774986"> Mikszáth Kálmán (1847-1910)
+            <title ref="wikidata:Q1296683">Szent Péter esernyője : ELTeC edition</title>
+            <author ref="viaf:46774986 wikidata:Q350552"> Mikszáth Kálmán (1847-1910)
             </author>
             <respStmt>
                <resp>ELTeC conversion</resp>

--- a/level1/HU00977.xml
+++ b/level1/HU00977.xml
@@ -7,8 +7,8 @@
    <teiHeader>
       <fileDesc>
          <titleStmt>
-            <title>Rab ember fiai : ELTeC edition</title>
-            <author ref="viaf:73857588">Móra Ferenc (1879-1934)</author>
+            <title ref="wikidata:Q111172508">Rab ember fiai : ELTeC edition</title>
+            <author ref="viaf:73857588 wikidata:Q774280">Móra Ferenc (1879-1934)</author>
             <respStmt>
                <resp>ELTeC conversion</resp>
                <name>Palkó Gábor<ref target="https://viaf.org/viaf/65989506"/>

--- a/level1/HU01009.xml
+++ b/level1/HU01009.xml
@@ -7,8 +7,8 @@
    <teiHeader>
       <fileDesc>
          <titleStmt>
-            <title>A hóhér kötele : ELTeC edition</title>
-            <author ref="viaf:59087691">Petőfi Sándor (1823-1849)</author>
+            <title ref="wikidata:Q467080">A hóhér kötele : ELTeC edition</title>
+            <author ref="viaf:59087691 wikidata:Q81219">Petőfi Sándor (1823-1849)</author>
             <respStmt>
                <resp>ELTeC conversion</resp>
                <name>Palkó Gábor<ref target="https://viaf.org/viaf/65989506"/>

--- a/level1/HU01115.xml
+++ b/level1/HU01115.xml
@@ -7,8 +7,8 @@
    <teiHeader>
       <fileDesc>
          <titleStmt>
-            <title>Egy alispán : Magyar korrajz : ELTeC edition</title>
-            <author ref="viaf:36952007">Vas Gereben (1823-1868)</author>
+            <title ref="wikidata:Q111172466">Egy alispán : Magyar korrajz : ELTeC edition</title>
+            <author ref="viaf:36952007 wikidata:Q277488">Vas Gereben (1823-1868)</author>
             <respStmt>
                <resp>ELTeC conversion</resp>
                <name>Palkó Gábor<ref target="https://viaf.org/viaf/65989506"/>

--- a/level1/HU01116.xml
+++ b/level1/HU01116.xml
@@ -7,8 +7,8 @@
    <teiHeader>
       <fileDesc>
          <titleStmt>
-            <title>Nagy idők, nagy emberek : ELTeC edition</title>
-            <author ref="viaf:36952007">Vas Gereben (1823-1868)</author>
+            <title ref="wikidata:Q111172503">Nagy idők, nagy emberek : ELTeC edition</title>
+            <author ref="viaf:36952007 wikidata:Q277488">Vas Gereben (1823-1868)</author>
             <respStmt>
                <resp>ELTeC conversion</resp>
                <name>Palkó Gábor<ref target="https://viaf.org/viaf/65989506"/>

--- a/level1/HU02028.xml
+++ b/level1/HU02028.xml
@@ -7,8 +7,8 @@
    <teiHeader>
       <fileDesc>
          <titleStmt>
-            <title>Színek és évek : ELTeC edition</title>
-            <author ref="viaf:19708135">Kaffka Margit (1880-1918)
+            <title ref="wikidata:Q111172517">Színek és évek : ELTeC edition</title>
+            <author ref="viaf:19708135 wikidata:Q287762">Kaffka Margit (1880-1918)
             </author>
             <respStmt>
                <resp>ELTeC conversion</resp>

--- a/level1/HU02143.xml
+++ b/level1/HU02143.xml
@@ -7,8 +7,8 @@
    <teiHeader>
       <fileDesc>
          <titleStmt>
-            <title>A pörös atyafiak : Regény : ELTeC edition</title>
-            <author ref="viaf:36952007">Vas Gereben (1823-1868)</author>
+            <title ref="wikidata:Q111172439">A pörös atyafiak : Regény : ELTeC edition</title>
+            <author ref="viaf:36952007 wikidata:Q277488">Vas Gereben (1823-1868)</author>
             <respStmt>
                <resp>ELTeC conversion</resp>
                <name>Palkó Gábor<ref target="https://viaf.org/viaf/65989506"/>

--- a/level1/HU02204.xml
+++ b/level1/HU02204.xml
@@ -7,8 +7,8 @@
    <teiHeader>
       <fileDesc>
          <titleStmt>
-            <title>A kétszarvú ember : ELTeC edition</title>
-            <author ref="viaf:59084200">Jókai Mór (1825-1904)</author>
+            <title ref="wikidata:Q111172428">A kétszarvú ember : ELTeC edition</title>
+            <author ref="viaf:59084200 wikidata:Q379621">Jókai Mór (1825-1904)</author>
             <respStmt>
                <resp>ELTeC conversion</resp>
                <name>Palkó Gábor<ref target="https://viaf.org/viaf/65989506"/>

--- a/level1/HU03130.xml
+++ b/level1/HU03130.xml
@@ -7,8 +7,8 @@
    <teiHeader>
       <fileDesc>
          <titleStmt>
-            <title>A karthauzi : ELTeC edition</title>
-            <author ref="viaf:64044769">Eötvös József (1813-1871)</author>
+            <title ref="wikidata:Q111172427">A karthauzi : ELTeC edition</title>
+            <author ref="viaf:64044769 wikidata:Q469996">Eötvös József (1813-1871)</author>
             <respStmt>
                <resp>ELTeC conversion</resp>
                <name>Palkó Gábor<ref target="https://viaf.org/viaf/65989506"/>

--- a/level1/HU04774.xml
+++ b/level1/HU04774.xml
@@ -7,8 +7,8 @@
    <teiHeader>
       <fileDesc>
          <titleStmt>
-            <title>Magyarország 1514-ben : Regény : ELTeC edition</title>
-            <author ref="viaf:64044769">Eötvös József (1813-1871)</author>
+            <title ref="wikidata:Q111172500">Magyarország 1514-ben : Regény : ELTeC edition</title>
+            <author ref="viaf:64044769 wikidata:Q469996">Eötvös József (1813-1871)</author>
             <respStmt>
                <resp>ELTeC conversion</resp>
                <name>Palkó Gábor<ref target="https://viaf.org/viaf/65989506"/>

--- a/level1/HU05060.xml
+++ b/level1/HU05060.xml
@@ -7,8 +7,8 @@
    <teiHeader>
       <fileDesc>
          <titleStmt>
-            <title>Sárarany : ELTeC edition</title>
-            <author ref="viaf:22179627">Móricz Zsigmond (1879-1942)</author>
+            <title ref="wikidata:Q111172512">Sárarany : ELTeC edition</title>
+            <author ref="viaf:22179627 wikidata:Q227312">Móricz Zsigmond (1879-1942)</author>
             <respStmt>
                <resp>ELTeC conversion</resp>
                <name>Palkó Gábor<ref target="https://viaf.org/viaf/65989506"/>

--- a/level1/HU05286.xml
+++ b/level1/HU05286.xml
@@ -7,8 +7,8 @@
    <teiHeader>
       <fileDesc>
          <titleStmt>
-            <title>Midas király : ELTeC edition</title>
-            <author ref="viaf:49239294">Ambrus Zoltán (1861-1932)</author>
+            <title ref="wikidata:Q111172502">Midas király : ELTeC edition</title>
+            <author ref="viaf:49239294 wikidata:Q373131">Ambrus Zoltán (1861-1932)</author>
             <respStmt>
                <resp>ELTeC conversion</resp>
                <name>Palkó Gábor<ref target="https://viaf.org/viaf/65989506"/>

--- a/level1/HU05572.xml
+++ b/level1/HU05572.xml
@@ -7,8 +7,8 @@
    <teiHeader>
       <fileDesc>
          <titleStmt>
-            <title>Egy magyar nábob : 1853-54 : ELTeC edition</title>
-            <author ref="viaf:59084200">Jókai Mór (1825-1904)</author>
+            <title ref="wikidata:Q987994">Egy magyar nábob : 1853-54 : ELTeC edition</title>
+            <author ref="viaf:59084200 wikidata:Q379621">Jókai Mór (1825-1904)</author>
             <respStmt>
                <resp>ELTeC conversion</resp>
                <name>Palkó Gábor<ref target="https://viaf.org/viaf/65989506"/>

--- a/level1/HU05573.xml
+++ b/level1/HU05573.xml
@@ -7,8 +7,8 @@
    <teiHeader>
       <fileDesc>
          <titleStmt>
-            <title>És mégis mozog a föld : ELTeC edition</title>
-            <author ref="viaf:59084200">Jókai Mór (1825-1904)</author>
+            <title ref="wikidata:Q111172473">És mégis mozog a föld : ELTeC edition</title>
+            <author ref="viaf:59084200 wikidata:Q379621">Jókai Mór (1825-1904)</author>
             <respStmt>
                <resp>ELTeC conversion</resp>
                <name>Palkó Gábor<ref target="https://viaf.org/viaf/65989506"/>

--- a/level1/HU05620.xml
+++ b/level1/HU05620.xml
@@ -7,8 +7,8 @@
    <teiHeader>
       <fileDesc>
          <titleStmt>
-            <title>Zord idő : ELTeC edition</title>
-            <author ref="viaf:54141095">Kemény Zsigmond (1814-1875)</author>
+            <title ref="wikidata:Q111172525">Zord idő : ELTeC edition</title>
+            <author ref="viaf:54141095 wikidata:Q427079">Kemény Zsigmond (1814-1875)</author>
             <respStmt>
                <resp>ELTeC conversion</resp>
                <name>Palkó Gábor<ref target="https://viaf.org/viaf/65989506"/>

--- a/level1/HU05964.xml
+++ b/level1/HU05964.xml
@@ -7,7 +7,7 @@
    <teiHeader>
       <fileDesc>
          <titleStmt>
-            <title>Piroska : ELTeC edition</title>
+            <title ref="wikidata:Q111172506">Piroska : ELTeC edition</title>
             <author ref="viaf:na">Cholnoky László (1879-1929)</author>
             <respStmt>
                <resp>ELTeC conversion</resp>

--- a/level1/HU06784.xml
+++ b/level1/HU06784.xml
@@ -7,8 +7,8 @@
    <teiHeader>
       <fileDesc>
          <titleStmt>
-            <title>Korhadt fakeresztek : képek a magyar szabadságról  : ELTeC edition </title>
-            <author ref="viaf:58030320">Rákosi Viktor (1860-1923)</author>
+            <title ref="wikidata:Q1118960">Korhadt fakeresztek : képek a magyar szabadságról  : ELTeC edition </title>
+            <author ref="viaf:58030320 wikidata:Q339428">Rákosi Viktor (1860-1923)</author>
             <respStmt>
                <resp>ELTeC conversion</resp>
                <name>Palkó Gábor<ref target="https://viaf.org/viaf/65989506"/>

--- a/level1/HU06982.xml
+++ b/level1/HU06982.xml
@@ -7,8 +7,8 @@
    <teiHeader>
       <fileDesc>
          <titleStmt>
-            <title>A lámpás : Regény : ELTeC edition</title>
-            <author ref="viaf:24643507">Gárdonyi Géza (1863-1922)</author>
+            <title ref="wikidata:Q111172431">A lámpás : Regény : ELTeC edition</title>
+            <author ref="viaf:24643507 wikidata:Q221903">Gárdonyi Géza (1863-1922)</author>
             <respStmt>
                <resp>ELTeC conversion</resp>
                <name>Palkó Gábor<ref target="https://viaf.org/viaf/65989506"/>

--- a/level1/HU07119.xml
+++ b/level1/HU07119.xml
@@ -7,7 +7,7 @@
    <teiHeader>
       <fileDesc>
          <titleStmt>
-            <title>Kaleidoszkop : ELTeC edition</title>
+            <title ref="wikidata:Q111172483">Kaleidoszkop : ELTeC edition</title>
             <author ref="viaf:na">Cholnoky Viktor (1868-1912)</author>
             <respStmt>
                <resp>ELTeC conversion</resp>

--- a/level1/HU07551.xml
+++ b/level1/HU07551.xml
@@ -7,8 +7,8 @@
    <teiHeader>
       <fileDesc>
          <titleStmt>
-            <title>Magyar titkok : Regény : ELTeC edition</title>
-            <author ref="viaf:121393539">Nagy Ignác (1810-1854)</author>
+            <title ref="wikidata:Q1162553">Magyar titkok : Regény : ELTeC edition</title>
+            <author ref="viaf:121393539 wikidata:Q793620">Nagy Ignác (1810-1854)</author>
             <respStmt>
                <resp>ELTeC conversion</resp>
                <name>Palkó Gábor<ref target="https://viaf.org/viaf/65989506"/>

--- a/level1/HU07552.xml
+++ b/level1/HU07552.xml
@@ -7,8 +7,8 @@
    <teiHeader>
       <fileDesc>
          <titleStmt>
-            <title>Hazai rejtelmek : Regény : ELTeC edition</title>
-            <author ref="viaf:29522559">Kuthy Lajos (1813-1864)</author>
+            <title ref="wikidata:Q1034577">Hazai rejtelmek : Regény : ELTeC edition</title>
+            <author ref="viaf:29522559 wikidata:Q509734">Kuthy Lajos (1813-1864)</author>
             <respStmt>
                <resp>ELTeC conversion</resp>
                <name>Palkó Gábor<ref target="https://viaf.org/viaf/65989506"/>

--- a/level1/HU07629.xml
+++ b/level1/HU07629.xml
@@ -7,8 +7,8 @@
    <teiHeader>
       <fileDesc>
          <titleStmt>
-            <title>Az alföldi vadászok tanyája : Regény : ELTeC edition</title>
-            <author ref="viaf:25795116">Podmaniczky Frigyes (1824-1907)</author>
+            <title ref="wikidata:Q111172450">Az alföldi vadászok tanyája : Regény : ELTeC edition</title>
+            <author ref="viaf:25795116 wikidata:Q1237824">Podmaniczky Frigyes (1824-1907)</author>
             <respStmt>
                <resp>ELTeC conversion</resp>
                <name>Palkó Gábor<ref target="https://viaf.org/viaf/65989506"/>

--- a/level1/HU07693.xml
+++ b/level1/HU07693.xml
@@ -7,8 +7,8 @@
    <teiHeader>
       <fileDesc>
          <titleStmt>
-            <title>A száműzött leánya : Regény : ELTeC edition</title>
-            <author ref="viaf:25034532">Degré Alajos (1819–1896) </author>
+            <title ref="wikidata:Q111172442">A száműzött leánya : Regény : ELTeC edition</title>
+            <author ref="viaf:25034532 wikidata:Q903380">Degré Alajos (1819–1896) </author>
             <respStmt>
                <resp>ELTeC conversion</resp>
                <name>Palkó Gábor<ref target="https://viaf.org/viaf/65989506"/>

--- a/level1/HU07694.xml
+++ b/level1/HU07694.xml
@@ -7,8 +7,8 @@
    <teiHeader>
       <fileDesc>
          <titleStmt>
-            <title>Anatole :  Regény  : ELTeC edition</title>
-            <author ref="viaf:56032353">Toldy István (1844-1879)
+            <title ref="wikidata:Q111172448">Anatole :  Regény  : ELTeC edition</title>
+            <author ref="viaf:56032353 wikidata:Q1184683">Toldy István (1844-1879)
             </author>
             <respStmt>
                <resp>ELTeC conversion</resp>

--- a/level1/HU07703.xml
+++ b/level1/HU07703.xml
@@ -7,8 +7,8 @@
    <teiHeader>
       <fileDesc>
          <titleStmt>
-            <title>A kis tündér : Regény : ELTeC edition</title>
-            <author ref="viaf:120125275">Vadnai Károly (1832-1902)</author>
+            <title ref="wikidata:Q111172429">A kis tündér : Regény : ELTeC edition</title>
+            <author ref="viaf:120125275 wikidata:Q1251968">Vadnai Károly (1832-1902)</author>
             <respStmt>
                <resp>ELTeC conversion</resp>
                <name>Palkó Gábor<ref target="https://viaf.org/viaf/65989506"/>

--- a/level1/HU07718.xml
+++ b/level1/HU07718.xml
@@ -7,8 +7,8 @@
    <teiHeader>
       <fileDesc>
          <titleStmt>
-            <title>Kálozdy Béla : Regény : ELTeC edition</title>
-            <author ref="viaf:73093732">Beöthy Zsolt (1791-1860)</author>
+            <title ref="wikidata:Q111172484">Kálozdy Béla : Regény : ELTeC edition</title>
+            <author ref="viaf:73093732 wikidata:Q794461">Beöthy Zsolt (1791-1860)</author>
             <respStmt>
                <resp>ELTeC conversion</resp>
                <name>Palkó Gábor<ref target="https://viaf.org/viaf/65989506"/>

--- a/level1/HU07729.xml
+++ b/level1/HU07729.xml
@@ -7,8 +7,8 @@
     <teiHeader>
         <fileDesc>
             <titleStmt>
-                <title>Aranyfüst : ELTeC kiadás</title>
-                <author ref="viaf:121454816">Wohl Stefánia (1848-1889)</author>
+                <title ref="wikidata:Q111172449">Aranyfüst : ELTeC kiadás</title>
+                <author ref="viaf:121454816 wikidata:Q1465296">Wohl Stefánia (1848-1889)</author>
                 <respStmt>
                     <resp>ELTeC conversion</resp>
                     <name>Palkó Gábor<ref target="https://viaf.org/viaf/65989506"/>

--- a/level1/HU08163.xml
+++ b/level1/HU08163.xml
@@ -7,8 +7,8 @@
    <teiHeader>
       <fileDesc>
          <titleStmt>
-            <title>Jávor orvos és szolgája, Bakator Ambrus: Szeszélyes regény: ELTeC edition</title>
-            <author ref="viaf:17278550">Fáy András (1786-1864)
+            <title ref="wikidata:Q111172482">Jávor orvos és szolgája, Bakator Ambrus: Szeszélyes regény: ELTeC edition</title>
+            <author ref="viaf:17278550 wikidata:Q4774">Fáy András (1786-1864)
             </author>
             <respStmt>
                <resp>ELTeC conversion</resp>

--- a/level1/HU08358.xml
+++ b/level1/HU08358.xml
@@ -7,8 +7,8 @@
    <teiHeader>
       <fileDesc>
          <titleStmt>
-            <title>Édes anyaföldem! :  Egy nép s egy ember története  : ELTeC edition</title>
-            <author ref="viaf:120201932"> Benedek Elek (1859-1929)
+            <title ref="wikidata:Q111172463">Édes anyaföldem! :  Egy nép s egy ember története  : ELTeC edition</title>
+            <author ref="viaf:120201932 wikidata:Q521014"> Benedek Elek (1859-1929)
             </author>
             <respStmt>
                <resp>ELTeC conversion</resp>

--- a/level1/HU09105.xml
+++ b/level1/HU09105.xml
@@ -7,8 +7,8 @@
    <teiHeader>
       <fileDesc>
          <titleStmt>
-            <title>A zöldköves gyűrű : Regény : ELTeC edition</title>
-            <author ref="viaf:72194515">Török Gyula (1888-1918)</author>
+            <title ref="wikidata:Q111172444">A zöldköves gyűrű : Regény : ELTeC edition</title>
+            <author ref="viaf:72194515 wikidata:Q1328186">Török Gyula (1888-1918)</author>
             <respStmt>
                <resp>ELTeC conversion</resp>
                <name>Palkó Gábor<ref target="https://viaf.org/viaf/65989506"/>

--- a/level1/HU10428.xml
+++ b/level1/HU10428.xml
@@ -7,8 +7,8 @@
    <teiHeader>
       <fileDesc>
          <titleStmt>
-            <title>A csipkeverő leány : Regény : ELTeC edition</title>
-            <author ref="viaf:73382097">Szomaházy István (1864-1927)</author>
+            <title ref="wikidata:Q111172419">A csipkeverő leány : Regény : ELTeC edition</title>
+            <author ref="viaf:73382097 wikidata:Q1299838">Szomaházy István (1864-1927)</author>
             <respStmt>
                <resp>ELTeC conversion</resp>
                <name>Palkó Gábor<ref target="https://viaf.org/viaf/65989506"/>

--- a/level1/HU11129.xml
+++ b/level1/HU11129.xml
@@ -7,7 +7,7 @@
    <teiHeader>
       <fileDesc>
          <titleStmt>
-            <title>Bébike memoárjai : Egy kis kutya önéletrajza : ELTeC edition</title>
+            <title ref="wikidata:Q111172457">Bébike memoárjai : Egy kis kutya önéletrajza : ELTeC edition</title>
             <author>Andor Mária (1890-1960)</author>
             <respStmt>
                <resp>ELTeC conversion</resp>

--- a/level1/HU11795.xml
+++ b/level1/HU11795.xml
@@ -7,8 +7,8 @@
    <teiHeader>
       <fileDesc>
          <titleStmt>
-            <title>Rontó Pál viselt dolgai vizen és szárazon : ELTeC kiadás</title>
-            <author ref="viaf:19711540">
+            <title ref="wikidata:Q111172510">Rontó Pál viselt dolgai vizen és szárazon : ELTeC kiadás</title>
+            <author ref="viaf:19711540 wikidata:Q323898">
                Ágai Adolf (1836-1916)
             </author>
             <respStmt>

--- a/level1/HU11968.xml
+++ b/level1/HU11968.xml
@@ -7,8 +7,8 @@
 <teiHeader>
         <fileDesc>
             <titleStmt>
-                <title>Őserdőkön, tengereken : ELTeC kiadás</title>
-                <author ref="viaf:1657716 ">Donászy Ferenc (1858-1923)</author>
+                <title ref="wikidata:Q111172504">Őserdőkön, tengereken : ELTeC kiadás</title>
+                <author ref="viaf:1657716  wikidata:Q908867">Donászy Ferenc (1858-1923)</author>
                 <respStmt>
                     <resp>ELTeC conversion</resp>
                     <name>Palkó Gábor<ref target="https://viaf.org/viaf/65989506"/>

--- a/level1/HU12028.xml
+++ b/level1/HU12028.xml
@@ -7,8 +7,8 @@
    <teiHeader>
       <fileDesc>
          <titleStmt>
-            <title>A nagyasszony : Regény : ELTeC edition</title>
-            <author ref="viaf:39125767">Abonyi Árpád (1865-1918)</author>
+            <title ref="wikidata:Q111172436">A nagyasszony : Regény : ELTeC edition</title>
+            <author ref="viaf:39125767 wikidata:Q279011">Abonyi Árpád (1865-1918)</author>
             <respStmt>
                <resp>ELTeC conversion</resp>
                <name>Palkó Gábor<ref target="https://viaf.org/viaf/65989506"/>

--- a/level1/HU12359.xml
+++ b/level1/HU12359.xml
@@ -7,8 +7,8 @@
    <teiHeader>
       <fileDesc>
          <titleStmt>
-            <title>A parasztkirály : Történeti regény a XVI. századból : ELTeC edition</title>
-            <author ref="viaf:70701164">Zigány Árpád (1865-1936)</author>
+            <title ref="wikidata:Q111172438">A parasztkirály : Történeti regény a XVI. századból : ELTeC edition</title>
+            <author ref="viaf:70701164 wikidata:Q58485677">Zigány Árpád (1865-1936)</author>
             <respStmt>
                <resp>ELTeC conversion</resp>
                <name>Palkó Gábor<ref target="https://viaf.org/viaf/65989506"/>

--- a/level1/HU12750.xml
+++ b/level1/HU12750.xml
@@ -7,8 +7,8 @@
    <teiHeader>
       <fileDesc>
          <titleStmt>
-            <title>A rab király szabadon : Fantasztikus állatregény : ELTeC edition</title>
-            <author ref="viaf:84079235">Bársony István (1863-1924)</author>
+            <title ref="wikidata:Q111172441">A rab király szabadon : Fantasztikus állatregény : ELTeC edition</title>
+            <author ref="viaf:84079235 wikidata:Q331431">Bársony István (1863-1924)</author>
             <respStmt>
                <resp>ELTeC conversion</resp>
                <name>Palkó Gábor<ref target="https://viaf.org/viaf/65989506"/>

--- a/level1/HU13316.xml
+++ b/level1/HU13316.xml
@@ -7,9 +7,9 @@
    <teiHeader>
       <fileDesc>
          <titleStmt>
-            <title>A Kont-eset :  Fantasztikus regény a XXI. századból  : ELTeC edition
+            <title ref="wikidata:Q111172430">A Kont-eset :  Fantasztikus regény a XXI. századból  : ELTeC edition
             </title>
-            <author ref="viaf:121485073">Szemere György (1866-1952)
+            <author ref="viaf:121485073 wikidata:Q1089877">Szemere György (1866-1952)
             </author>
             <respStmt>
                <resp>ELTeC conversion</resp>

--- a/level1/HU13387.xml
+++ b/level1/HU13387.xml
@@ -7,8 +7,8 @@
    <teiHeader>
       <fileDesc>
          <titleStmt>
-            <title>Egri csillagok: Bornemissza Gergely élete: ELTeC edition</title>
-            <author ref="viaf:24643507"> Gárdonyi Géza (1863-1922) 
+            <title ref="wikidata:Q987956">Egri csillagok: Bornemissza Gergely élete: ELTeC edition</title>
+            <author ref="viaf:24643507 wikidata:Q221903"> Gárdonyi Géza (1863-1922) 
             </author>
             <respStmt>
                <resp>ELTeC conversion</resp>

--- a/level1/HU13445.xml
+++ b/level1/HU13445.xml
@@ -7,8 +7,8 @@
    <teiHeader>
       <fileDesc>
          <titleStmt>
-            <title>Két leány és egy legény : Regény : ELTeC edition</title>
-            <author ref="viaf:121409411">Beöthy László (1826-1857)</author>
+            <title ref="wikidata:Q111172488">Két leány és egy legény : Regény : ELTeC edition</title>
+            <author ref="viaf:121409411 wikidata:Q794452">Beöthy László (1826-1857)</author>
             <respStmt>
                <resp>ELTeC conversion</resp>
                <name>Palkó Gábor<ref target="https://viaf.org/viaf/65989506"/>

--- a/level1/HU13462.xml
+++ b/level1/HU13462.xml
@@ -7,8 +7,8 @@
    <teiHeader>
       <fileDesc>
          <titleStmt>
-            <title>Két világ közt : Regény : ELTeC edition</title>
-            <author ref="viaf:121505002">Kövér Ilma (1862-1928)</author>
+            <title ref="wikidata:Q111172490">Két világ közt : Regény : ELTeC edition</title>
+            <author ref="viaf:121505002 wikidata:Q1125796">Kövér Ilma (1862-1928)</author>
             <respStmt>
                <resp>ELTeC conversion</resp>
                <name>Palkó Gábor<ref target="https://viaf.org/viaf/65989506"/>

--- a/level1/HU13606.xml
+++ b/level1/HU13606.xml
@@ -7,8 +7,8 @@
    <teiHeader>
       <fileDesc>
          <titleStmt>
-            <title>Forgách Simon : Rákóczi korabeli regény : ELTeC edition</title>
-            <author ref="viaf:167135256">Werner Gyula (1862-1926)</author>
+            <title ref="wikidata:Q111172476">Forgách Simon : Rákóczi korabeli regény : ELTeC edition</title>
+            <author ref="viaf:167135256 wikidata:Q1464390">Werner Gyula (1862-1926)</author>
             <respStmt>
                <resp>ELTeC conversion</resp>
                <name>Palkó Gábor<ref target="https://viaf.org/viaf/65989506"/>

--- a/level1/HU13802.xml
+++ b/level1/HU13802.xml
@@ -7,8 +7,8 @@
    <teiHeader>
       <fileDesc>
          <titleStmt>
-            <title>Magduska öröksége : Regény : ELTeC edition</title>
-            <author ref="viaf:68652301">Abonyi Lajos (1833-1898)</author>
+            <title ref="wikidata:Q111172497">Magduska öröksége : Regény : ELTeC edition</title>
+            <author ref="viaf:68652301 wikidata:Q323626">Abonyi Lajos (1833-1898)</author>
             <respStmt>
                <resp>ELTeC conversion</resp>
                <name>Palkó Gábor<ref target="https://viaf.org/viaf/65989506"/>

--- a/level1/HU14125.xml
+++ b/level1/HU14125.xml
@@ -7,8 +7,8 @@
    <teiHeader>
       <fileDesc>
          <titleStmt>
-            <title>Sisyphus munkája : Regény : ELTeC edition</title>
-            <author ref="viaf:54198282">Csiky Gergely (1842-1891)</author>
+            <title ref="wikidata:Q111172513">Sisyphus munkája : Regény : ELTeC edition</title>
+            <author ref="viaf:54198282 wikidata:Q166952">Csiky Gergely (1842-1891)</author>
             <respStmt>
                <resp>ELTeC conversion</resp>
                <name>Palkó Gábor<ref target="https://viaf.org/viaf/65989506"/>

--- a/level1/HU14197.xml
+++ b/level1/HU14197.xml
@@ -8,7 +8,7 @@
       <fileDesc>
          <titleStmt>
             <title>A legszebb herczegnő : Történeti regény Mária Terézia korából : ELTeC edition</title>
-            <author ref="viaf:57487056">Szathmáry Károly, P. (1831-1891)</author>
+            <author ref="viaf:57487056 wikidata:Q1227353">Szathmáry Károly, P. (1831-1891)</author>
             <respStmt>
                <resp>ELTeC conversion</resp>
                <name>Palkó Gábor<ref target="https://viaf.org/viaf/65989506"/>

--- a/level1/HU14261.xml
+++ b/level1/HU14261.xml
@@ -7,8 +7,8 @@
    <teiHeader>
       <fileDesc>
          <titleStmt>
-            <title>Lavina :  Regény  : ELTeC edition</title>
-            <author ref="viaf:2057726">Pekár Gyula (1867-1937)
+            <title ref="wikidata:Q111172496">Lavina :  Regény  : ELTeC edition</title>
+            <author ref="viaf:2057726 wikidata:Q1232089">Pekár Gyula (1867-1937)
             </author>
             <respStmt>
                <resp>ELTeC conversion</resp>

--- a/level1/HU14315.xml
+++ b/level1/HU14315.xml
@@ -7,8 +7,8 @@
    <teiHeader>
       <fileDesc>
          <titleStmt>
-            <title>Képzelt királyok : Történeti regény : ELTeC edition</title>
-            <author ref="viaf:162003783">Kupa Árpád (1858-1916)</author>
+            <title ref="wikidata:Q111172485">Képzelt királyok : Történeti regény : ELTeC edition</title>
+            <author ref="viaf:162003783 wikidata:Q1122077">Kupa Árpád (1858-1916)</author>
             <respStmt>
                <resp>ELTeC conversion</resp>
                <name>Palkó Gábor<ref target="https://viaf.org/viaf/65989506"/>

--- a/level1/HU14548.xml
+++ b/level1/HU14548.xml
@@ -8,7 +8,7 @@
       <fileDesc>
          <titleStmt>
             <title>Régi és uj nemesek : Eredeti regény : ELTeC edition</title>
-            <author ref="viaf:57808720">Ábrányi Kornél (1849-1913)</author>
+            <author ref="viaf:57808720 wikidata:Q1074680">Ábrányi Kornél (1849-1913)</author>
             <respStmt>
                <resp>ELTeC conversion</resp>
                <name>Palkó Gábor<ref target="https://viaf.org/viaf/65989506"/>

--- a/level1/HU14564.xml
+++ b/level1/HU14564.xml
@@ -7,8 +7,8 @@
    <teiHeader>
       <fileDesc>
          <titleStmt>
-            <title>Kisvárosiak: Regény: ELTeC edition</title>
-            <author ref="viaf:53161612"> Herman Ottóné (1856-1916)
+            <title ref="wikidata:Q111172491">Kisvárosiak: Regény: ELTeC edition</title>
+            <author ref="viaf:53161612 wikidata:Q12353551"> Herman Ottóné (1856-1916)
             </author>
             <respStmt>
                <resp>ELTeC conversion</resp>

--- a/level1/HU14664.xml
+++ b/level1/HU14664.xml
@@ -7,8 +7,8 @@
    <teiHeader>
       <fileDesc>
          <titleStmt>
-            <title>Életképek : ELTeC edition</title>
-            <author ref="viaf:6903976">Tolnai Lajos (1837-1902)</author>
+            <title ref="wikidata:Q111172471">Életképek : ELTeC edition</title>
+            <author ref="viaf:6903976 wikidata:Q676593">Tolnai Lajos (1837-1902)</author>
             <respStmt>
                <resp>ELTeC conversion</resp>
                <name>Palkó Gábor<ref target="https://viaf.org/viaf/65989506"/>

--- a/level1/HU14689.xml
+++ b/level1/HU14689.xml
@@ -7,8 +7,8 @@
    <teiHeader>
       <fileDesc>
          <titleStmt>
-            <title>Előre : Regény : ELTeC edition</title>
-            <author ref="viaf:121504813">Vértesi Arnold (1836-1911)</author>
+            <title ref="wikidata:Q111172472">Előre : Regény : ELTeC edition</title>
+            <author ref="viaf:121504813 wikidata:Q1387195">Vértesi Arnold (1836-1911)</author>
             <respStmt>
                <resp>ELTeC conversion</resp>
                <name>Palkó Gábor<ref target="https://viaf.org/viaf/65989506"/>

--- a/level1/HU14745.xml
+++ b/level1/HU14745.xml
@@ -7,7 +7,7 @@
    <teiHeader>
       <fileDesc>
          <titleStmt>
-            <title>Két sziv harcza : Regény két kötetben : ELTeC edition</title>
+            <title ref="wikidata:Q111172489">Két sziv harcza : Regény két kötetben : ELTeC edition</title>
             <author ref="20466121">Beniczkyné Bajza Lenke (1839-1905)</author>
             <respStmt>
                <resp>ELTeC conversion</resp>

--- a/level1/HU14769.xml
+++ b/level1/HU14769.xml
@@ -7,8 +7,8 @@
    <teiHeader>
       <fileDesc>
          <titleStmt>
-            <title>Itt és a jövő életben : Regény két kötetben : ELTeC edition</title>
-            <author ref="viaf:20466121">Beniczkyné Bajza Lenke (1839-1905)</author>
+            <title ref="wikidata:Q111172481">Itt és a jövő életben : Regény két kötetben : ELTeC edition</title>
+            <author ref="viaf:20466121 wikidata:Q792910">Beniczkyné Bajza Lenke (1839-1905)</author>
             <respStmt>
                <resp>ELTeC conversion</resp>
                <name>Palkó Gábor<ref target="https://viaf.org/viaf/65989506"/>

--- a/level1/HU16123.xml
+++ b/level1/HU16123.xml
@@ -7,8 +7,8 @@
    <teiHeader>
       <fileDesc>
          <titleStmt>
-            <title>Az utolsó: Regény három kötetben: ELTeC edition</title>
-            <author ref="viaf:86172276"> Malonyay Dezső (1866-1916) 
+            <title ref="wikidata:Q111172455">Az utolsó: Regény három kötetben: ELTeC edition</title>
+            <author ref="viaf:86172276 wikidata:Q1164345"> Malonyay Dezső (1866-1916) 
             </author>
             <respStmt>
                <resp>ELTeC conversion</resp>

--- a/level1/HU16124.xml
+++ b/level1/HU16124.xml
@@ -7,8 +7,8 @@
    <teiHeader>
       <fileDesc>
          <titleStmt>
-            <title>A szemfényvesztők : Regény : ELTeC edition</title>
-            <author ref="viaf:121399672">Bartók Lajos (1851-1902)</author>
+            <title ref="wikidata:Q111172443">A szemfényvesztők : Regény : ELTeC edition</title>
+            <author ref="viaf:121399672 wikidata:Q791040">Bartók Lajos (1851-1902)</author>
             <respStmt>
                <resp>ELTeC conversion</resp>
                <name>Palkó Gábor<ref target="https://viaf.org/viaf/65989506"/>

--- a/level1/HU16127.xml
+++ b/level1/HU16127.xml
@@ -7,7 +7,7 @@
    <teiHeader>
       <fileDesc>
          <titleStmt>
-            <title>Salve Regina : Regény : ELTeC edition</title>
+            <title ref="wikidata:Q111172511">Salve Regina : Regény : ELTeC edition</title>
             <author ref="viaf:378155284786787061557">Palotás Fausztin (1855-1922)</author>
             <respStmt>
                <resp>ELTeC conversion</resp>

--- a/level1/HU16243.xml
+++ b/level1/HU16243.xml
@@ -7,7 +7,7 @@
    <teiHeader>
       <fileDesc>
          <titleStmt>
-            <title>A bukottak : Regény : ELTeC edition</title>
+            <title ref="wikidata:Q111172418">A bukottak : Regény : ELTeC edition</title>
             <author>Beksics Gusztávné (1849-1903)</author>
             <respStmt>
                <resp>ELTeC conversion</resp>

--- a/level1/HU16328.xml
+++ b/level1/HU16328.xml
@@ -8,8 +8,8 @@
    <teiHeader>
       <fileDesc>
          <titleStmt>
-            <title>Görbe hegyek országában : Regény : ELTeC edition</title>
-            <author ref="viaf:73060469">Tábori Róbert (1855-1906)</author>
+            <title ref="wikidata:Q111172477">Görbe hegyek országában : Regény : ELTeC edition</title>
+            <author ref="viaf:73060469 wikidata:Q1326046">Tábori Róbert (1855-1906)</author>
             <respStmt>
                <resp>ELTeC conversion</resp>
                <name>Palkó Gábor<ref target="https://viaf.org/viaf/65989506"/>

--- a/level1/HU16344.xml
+++ b/level1/HU16344.xml
@@ -7,8 +7,8 @@
     <teiHeader>
         <fileDesc>
             <titleStmt>
-                <title>A Bakony : ELTeC kiadás</title>
-                <author ref="viaf:184888089">Eötvös Károly (1842-1916)</author>
+                <title ref="wikidata:Q111172416">A Bakony : ELTeC kiadás</title>
+                <author ref="viaf:184888089 wikidata:Q994550">Eötvös Károly (1842-1916)</author>
                 <respStmt>
                     <resp>ELTeC conversion</resp>
                     <name>Palkó Gábor<ref target="https://viaf.org/viaf/"/>

--- a/level1/HU16355.xml
+++ b/level1/HU16355.xml
@@ -7,8 +7,8 @@
    <teiHeader>
       <fileDesc>
          <titleStmt>
-            <title>A darázs mérge : Regény : ELTeC edition</title>
-            <author ref="viaf:121449348">Kada Elek (1852-1913)</author>
+            <title ref="wikidata:Q111172420">A darázs mérge : Regény : ELTeC edition</title>
+            <author ref="viaf:121449348 wikidata:Q1103185">Kada Elek (1852-1913)</author>
             <respStmt>
                <resp>ELTeC conversion</resp>
                <name>Palkó Gábor<ref target="https://viaf.org/viaf/65989506"/>

--- a/level1/HU16359.xml
+++ b/level1/HU16359.xml
@@ -7,8 +7,8 @@
    <teiHeader>
       <fileDesc>
          <titleStmt>
-            <title>Félvér : Regény : ELTeC edition</title>
-            <author ref="viaf:162597297">Prém József (1850-1910)</author>
+            <title ref="wikidata:Q111172474">Félvér : Regény : ELTeC edition</title>
+            <author ref="viaf:162597297 wikidata:Q61070104">Prém József (1850-1910)</author>
             <respStmt>
                <resp>ELTeC conversion</resp>
                <name>Palkó Gábor<ref target="https://viaf.org/viaf/65989506"/>

--- a/level1/HU16361.xml
+++ b/level1/HU16361.xml
@@ -7,8 +7,8 @@
     <teiHeader>
         <fileDesc>
             <titleStmt>
-                <title>Vagy idejében vagy soha : ELTeC kiadás</title>
-                <author ref="viaf:121430064">Boross Mihály (1815-1899)</author>
+                <title ref="wikidata:Q111172523">Vagy idejében vagy soha : ELTeC kiadás</title>
+                <author ref="viaf:121430064 wikidata:Q835259">Boross Mihály (1815-1899)</author>
                 <respStmt>
                     <resp>ELTeC conversion</resp>
                     <name>Palkó Gábor<ref target="https://viaf.org/viaf/65989506"/>

--- a/level1/HU16529.xml
+++ b/level1/HU16529.xml
@@ -7,8 +7,8 @@
    <teiHeader>
       <fileDesc>
          <titleStmt>
-            <title>Csillagok a Tiszában : ELTeC kiadás</title>
-            <author ref="viaf:5289705"> Ábrahám Ernő(1882-1945)
+            <title ref="wikidata:Q111172461">Csillagok a Tiszában : ELTeC kiadás</title>
+            <author ref="viaf:5289705 wikidata:Q239250"> Ábrahám Ernő(1882-1945)
             </author>
             <respStmt>
                <resp>ELTeC conversion</resp>

--- a/level1/HU16600.xml
+++ b/level1/HU16600.xml
@@ -7,8 +7,8 @@
    <teiHeader>
       <fileDesc>
          <titleStmt>
-            <title>Az arany polgár : Regény : ELTeC edition</title>
-            <author ref="viaf:121536328">Lovik Károly (1874-1915)</author>
+            <title ref="wikidata:Q111172451">Az arany polgár : Regény : ELTeC edition</title>
+            <author ref="viaf:121536328 wikidata:Q567828">Lovik Károly (1874-1915)</author>
             <respStmt>
                <resp>ELTeC conversion</resp>
                <name>Palkó Gábor<ref target="https://viaf.org/viaf/65989506"/>

--- a/level1/HU16672.xml
+++ b/level1/HU16672.xml
@@ -7,8 +7,8 @@
     <teiHeader>
         <fileDesc>
             <titleStmt>
-                <title>Egy magyar amazon : ELTeC kiadás</title>
-                <author ref="viaf:221085154">Kovács József (1832-1897)</author>
+                <title ref="wikidata:Q111172468">Egy magyar amazon : ELTeC kiadás</title>
+                <author ref="viaf:221085154 wikidata:Q23938749">Kovács József (1832-1897)</author>
                 <respStmt>
                     <resp>ELTeC conversion</resp>
                     <name>Palkó Gábor<ref target="https://viaf.org/viaf/65989506"/>

--- a/level1/HU16824.xml
+++ b/level1/HU16824.xml
@@ -7,8 +7,8 @@
    <teiHeader>
       <fileDesc>
          <titleStmt>
-            <title>A nagy véletlen : ELTeC edition</title>
-            <author ref="viaf:121446803">Ritoók Emma (1868-1945)
+            <title ref="wikidata:Q111172435">A nagy véletlen : ELTeC edition</title>
+            <author ref="viaf:121446803 wikidata:Q1249352">Ritoók Emma (1868-1945)
             </author>
             <respStmt>
                <resp>ELTeC conversion</resp>

--- a/level1/HU17048.xml
+++ b/level1/HU17048.xml
@@ -7,8 +7,8 @@
    <teiHeader>
       <fileDesc>
          <titleStmt>
-            <title>A jövő fészke : ELTeC edition</title>
-            <author ref="viaf:51003824 ">Kabos Ede (1864-1923)</author>
+            <title ref="wikidata:Q111172426">A jövő fészke : ELTeC edition</title>
+            <author ref="viaf:51003824  wikidata:Q1103123">Kabos Ede (1864-1923)</author>
             <respStmt>
                <resp>ELTeC conversion</resp>
                <name>Palkó Gábor<ref target="https://viaf.org/viaf/65989506"/>

--- a/level1/HU17435.xml
+++ b/level1/HU17435.xml
@@ -7,8 +7,8 @@
     <teiHeader>
         <fileDesc>
             <titleStmt>
-                <title>Bujdosó könyv : ELTeC kiadás</title>
-                <author ref="viaf:49267950">Tormay Cécile (1876-1937)</author>
+                <title ref="wikidata:Q111172458">Bujdosó könyv : ELTeC kiadás</title>
+                <author ref="viaf:49267950 wikidata:Q241470">Tormay Cécile (1876-1937)</author>
                 <respStmt>
                     <resp>ELTeC conversion</resp>
                     <name>Palkó Gábor<ref target="https://viaf.org/viaf/"/>

--- a/level1/HU17606.xml
+++ b/level1/HU17606.xml
@@ -7,9 +7,9 @@
    <teiHeader>
       <fileDesc>
          <titleStmt>
-            <title>Tabu :  Regény  : ELTeC edition
+            <title ref="wikidata:Q111172519">Tabu :  Regény  : ELTeC edition
             </title>
-            <author ref="viaf:309595549"> Teleki Sándorné (1864-1937)
+            <author ref="viaf:309595549 wikidata:Q47516117"> Teleki Sándorné (1864-1937)
             </author>
             <respStmt>
                <resp>ELTeC conversion</resp>

--- a/level1/HU17653.xml
+++ b/level1/HU17653.xml
@@ -7,8 +7,8 @@
    <teiHeader>
       <fileDesc>
          <titleStmt>
-            <title>Két arany hajszál : Regény : ELTeC edition</title>
-            <author ref="viaf:1344243">Czóbel Minka (1855-1947)</author>
+            <title ref="wikidata:Q111172486">Két arany hajszál : Regény : ELTeC edition</title>
+            <author ref="viaf:1344243 wikidata:Q900169">Czóbel Minka (1855-1947)</author>
             <respStmt>
                <resp>ELTeC conversion</resp>
                <name>Palkó Gábor<ref target="https://viaf.org/viaf/65989506"/>

--- a/level1/HU17694.xml
+++ b/level1/HU17694.xml
@@ -7,8 +7,8 @@
    <teiHeader>
       <fileDesc>
          <titleStmt>
-            <title>Amire születtünk : Regény : ELTeC edition</title>
-            <author ref="viaf:121519574">Lux Terka (1873-1938)</author>
+            <title ref="wikidata:Q111172446">Amire születtünk : Regény : ELTeC edition</title>
+            <author ref="viaf:121519574 wikidata:Q20478099">Lux Terka (1873-1938)</author>
             <respStmt>
                <resp>ELTeC conversion</resp>
                <name>Palkó Gábor<ref target="https://viaf.org/viaf/65989506"/>

--- a/level1/HU17873.xml
+++ b/level1/HU17873.xml
@@ -7,7 +7,7 @@
     <teiHeader>
         <fileDesc>
             <titleStmt>
-                <title>Az élet esélyei: Regény: ELTeC edition </title>
+                <title ref="wikidata:Q111172452">Az élet esélyei: Regény: ELTeC edition </title>
                 <author ref="46218998"> Jósika Júlia (1813-1893)
                 </author>
                 <respStmt>

--- a/level1/HU17910.xml
+++ b/level1/HU17910.xml
@@ -7,8 +7,8 @@
     <teiHeader>
         <fileDesc>
             <titleStmt>
-                <title>Konrád : ELTeC kiadás</title>
-                <author ref="viaf:46218998">Jósika Júlia (1813-1893)</author>
+                <title ref="wikidata:Q111172493">Konrád : ELTeC kiadás</title>
+                <author ref="viaf:46218998 wikidata:Q1102800">Jósika Júlia (1813-1893)</author>
                 <respStmt>
                     <resp>ELTeC conversion</resp>
                     <name>Palkó Gábor<ref target="https://viaf.org/viaf/65989506"/>

--- a/level1/HU17960.xml
+++ b/level1/HU17960.xml
@@ -7,8 +7,8 @@
     <teiHeader>
         <fileDesc>
             <titleStmt>
-                <title>Egy cserepár naplója : ELTeC kiadás</title>
-                <author ref="viaf:121507699">Virághalmi Ferenc (1826-1875)</author>
+                <title ref="wikidata:Q111172467">Egy cserepár naplója : ELTeC kiadás</title>
+                <author ref="viaf:121507699 wikidata:Q1460204">Virághalmi Ferenc (1826-1875)</author>
                 <respStmt>
                     <resp>ELTeC conversion</resp>
                     <name>Palkó Gábor<ref target="https://viaf.org/viaf/65989506"/>

--- a/level1/HU17999.xml
+++ b/level1/HU17999.xml
@@ -7,7 +7,7 @@
    <teiHeader>
       <fileDesc>
          <titleStmt>
-            <title>Szeretet könyve : ELTeC edition</title>
+            <title ref="wikidata:Q111172516">Szeretet könyve : ELTeC edition</title>
             <author ref="30410778">Kánya Emília (1830-1910)
             </author>
             <respStmt>

--- a/level1/HU18153.xml
+++ b/level1/HU18153.xml
@@ -7,8 +7,8 @@
     <teiHeader>
         <fileDesc>
             <titleStmt>
-                <title>Szúnyogok : ELTeC kiadás</title>
-                <author ref="viaf:121393539">Nagy Ignác (1810-1854)</author>
+                <title ref="wikidata:Q111172518">Szúnyogok : ELTeC kiadás</title>
+                <author ref="viaf:121393539 wikidata:Q793620">Nagy Ignác (1810-1854)</author>
                 <respStmt>
                     <resp>ELTeC conversion</resp>
                     <name>Palkó Gábor<ref target="https://viaf.org/viaf/65989506"/>

--- a/level1/HU18411.xml
+++ b/level1/HU18411.xml
@@ -7,8 +7,8 @@
 <teiHeader>
     <fileDesc>
         <titleStmt>
-            <title>48-tól Világosig : ELTeC kiadás</title>
-            <author ref="viaf:164963805">Ábrai Károly (1830-1912)</author>
+            <title ref="wikidata:Q111172414">48-tól Világosig : ELTeC kiadás</title>
+            <author ref="viaf:164963805 wikidata:Q1469155">Ábrai Károly (1830-1912)</author>
             <respStmt>
                 <resp>ELTeC conversion</resp>
                 <name>Palkó Gábor<ref target="https://viaf.org/viaf/65989506"/>

--- a/level1/HU18535.xml
+++ b/level1/HU18535.xml
@@ -7,8 +7,8 @@
    <teiHeader>
       <fileDesc>
          <titleStmt>
-            <title>Köd :  Regény  : ELTeC edition</title>
-            <author ref="viaf:52610012">Gozsdu Elek (1863-1924)
+            <title ref="wikidata:Q111172492">Köd :  Regény  : ELTeC edition</title>
+            <author ref="viaf:52610012 wikidata:Q1027777">Gozsdu Elek (1863-1924)
             </author>
             <respStmt>
                <resp>ELTeC conversion</resp>

--- a/level1/HU18964.xml
+++ b/level1/HU18964.xml
@@ -7,8 +7,8 @@
     <teiHeader>
         <fileDesc>
             <titleStmt>
-                <title>Családélet : ELTeC kiadás</title>
-                <author ref="viaf:46218998">Jósika Júlia (1813-1893)</author>
+                <title ref="wikidata:Q111172460">Családélet : ELTeC kiadás</title>
+                <author ref="viaf:46218998 wikidata:Q1102800">Jósika Júlia (1813-1893)</author>
                 <respStmt>
                     <resp>ELTeC conversion</resp>
                     <name>Palkó Gábor<ref target="https://viaf.org/viaf/65989506"/>

--- a/level1/HU18993.xml
+++ b/level1/HU18993.xml
@@ -7,8 +7,8 @@
     <teiHeader>
         <fileDesc>
             <titleStmt>
-                <title>Válságos napok : ELTeC kiadás</title>
-                <author ref="viaf:30410778">Kánya Emília (1830–1910)</author>
+                <title ref="wikidata:Q111172524">Válságos napok : ELTeC kiadás</title>
+                <author ref="viaf:30410778 wikidata:Q1123196">Kánya Emília (1830–1910)</author>
                 <respStmt>
                     <resp>ELTeC conversion</resp>
                     <name>Palkó Gábor<ref target="https://viaf.org/viaf/65989506"/>

--- a/level1/HU19000.xml
+++ b/level1/HU19000.xml
@@ -7,8 +7,8 @@
    <teiHeader>
       <fileDesc>
          <titleStmt>
-            <title>Álmok álmodója : ELTeC edition</title>
-            <author ref="viaf:31986094">Asbóth János (1845-1911)
+            <title ref="wikidata:Q111172445">Álmok álmodója : ELTeC edition</title>
+            <author ref="viaf:31986094 wikidata:Q385634">Asbóth János (1845-1911)
             </author>
             <respStmt>
                <resp>ELTeC conversion</resp>

--- a/level1/HU19006.xml
+++ b/level1/HU19006.xml
@@ -7,8 +7,8 @@
     <teiHeader>
         <fileDesc>
             <titleStmt>
-                <title>Meghasonlott kedély : ELTeC kiadás</title>
-                <author ref="viaf:121426252">Kelmenfy László (1815-1851)</author>
+                <title ref="wikidata:Q1175458">Meghasonlott kedély : ELTeC kiadás</title>
+                <author ref="viaf:121426252 wikidata:Q1106516">Kelmenfy László (1815-1851)</author>
                 <respStmt>
                     <resp>ELTeC conversion</resp>
                     <name>Palkó Gábor<ref target="https://viaf.org/viaf/65989506"/>

--- a/level1/HU19018.xml
+++ b/level1/HU19018.xml
@@ -7,7 +7,7 @@
     <teiHeader>
         <fileDesc>
             <titleStmt>
-                <title>Margit : ELTeC kiadás</title>
+                <title ref="wikidata:Q111172501">Margit : ELTeC kiadás</title>
                 <author>Vachott Sándorné (1828-1896)</author>
                 <respStmt>
                     <resp>ELTeC conversion</resp>

--- a/level1/HU19040.xml
+++ b/level1/HU19040.xml
@@ -7,8 +7,8 @@
     <teiHeader>
         <fileDesc>
             <titleStmt>
-                <title>Torzképek : ELTeC kiadás</title>
-                <author ref="viaf:121393539">Nagy Ignác (1810-1854)</author>
+                <title ref="wikidata:Q111172522">Torzképek : ELTeC kiadás</title>
+                <author ref="viaf:121393539 wikidata:Q793620">Nagy Ignác (1810-1854)</author>
                 <respStmt>
                     <resp>ELTeC conversion</resp>
                     <name>Palkó Gábor<ref target="https://viaf.org/viaf/65989506"/>


### PR DESCRIPTION
Added wikidata:QXXXXX identifiers to the ref attribute of <title> and <author> elements in <titleStmt> for 99 level1 texts (1 skipped — no IDs found). Author IDs added: 88 | Work IDs added: 97
Wikidata IDs obtained via SPARQL (author: VIAF lookup; work: Hungarian @hu label search).